### PR TITLE
mpv-autocrop.py: Make python2 explicit in shebang.

### DIFF
--- a/mpv-autocrop.py
+++ b/mpv-autocrop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os,sys,argparse
 import mpv_utils
 try:


### PR DESCRIPTION
Explicitly requiring python2 as interpreter, this script now runs on systems that have their generic python symlinked to python3.
